### PR TITLE
Handle incomplete reads from StreamReader

### DIFF
--- a/aiozk/client.py
+++ b/aiozk/client.py
@@ -23,6 +23,7 @@ class ZKClient(object):
             default_acl=None,
             retry_policy=None,
             allow_read_only=False,
+            read_timeout=None
     ):
         self.chroot = None
         if chroot:
@@ -30,7 +31,7 @@ class ZKClient(object):
             log.info("Using chroot '%s'", self.chroot)
 
         self.session = Session(
-            servers, session_timeout, retry_policy, allow_read_only
+            servers, session_timeout, retry_policy, allow_read_only, read_timeout
         )
 
         self.default_acl = default_acl or [protocol.UNRESTRICTED_ACCESS]

--- a/aiozk/connection.py
+++ b/aiozk/connection.py
@@ -61,7 +61,7 @@ class Connection(object):
         log.debug("Sending 'srvr' command to %s:%d", self.host, self.port)
         self.writer.write(b"srvr")
 
-        answer = await self._read()
+        answer = await self.reader.read()
 
         version_line = answer.split(b"\n")[0]
         self.version_info = tuple(

--- a/aiozk/connection.py
+++ b/aiozk/connection.py
@@ -4,11 +4,13 @@ import logging
 import re
 import struct
 import sys
+from time import time
 
 # from tornado import ioloop, iostream, gen, concurrent, tcpclient
 
 from aiozk import protocol, iterables, exc
 
+DEFAULT_READ_TIMEOUT = 1
 
 version_regex = re.compile(rb'Zookeeper version: (\d)\.(\d)\.(\d)-.*')
 
@@ -25,7 +27,7 @@ if payload_log.level == logging.NOTSET:
 
 class Connection(object):
 
-    def __init__(self, host, port, watch_handler):
+    def __init__(self, host, port, watch_handler, read_timeout):
         self.loop = asyncio.get_event_loop()
         self.host = host
         self.port = int(port)
@@ -47,6 +49,8 @@ class Connection(object):
 
         self.watches = collections.defaultdict(list)
 
+        self.read_timeout = read_timeout or DEFAULT_READ_TIMEOUT
+
     async def connect(self):
         log.debug("Initial connection to server %s:%d", self.host, self.port)
         self.reader, self.writer = await asyncio.open_connection(self.host, self.port,
@@ -57,7 +61,7 @@ class Connection(object):
         log.debug("Sending 'srvr' command to %s:%d", self.host, self.port)
         self.writer.write(b"srvr")
 
-        answer = await self.reader.read()
+        answer = await self._read()
 
         version_line = answer.split(b"\n")[0]
         self.version_info = tuple(
@@ -168,19 +172,31 @@ class Connection(object):
             else:
                 f.set_result((zxid, response))
 
+    async def _read(self, size=-1):
+        remaining_size = size
+        payload = b''
+        end_time = time() + self.read_timeout
+        while remaining_size and (time() < end_time):
+            chunk = await self.reader.read(remaining_size)
+            payload += chunk
+            remaining_size -= len(chunk)
+        if remaining_size:
+            raise exc.UnfinishedRead
+        return payload
+
     async def read_response(self, initial_connect=False):
-        raw_size = await self.reader.read(size_struct.size)
+        raw_size = await self._read(size_struct.size)
         if raw_size == b'':
             raise ConnectionAbortedError
         size = size_struct.unpack(raw_size)[0]
 
         # connect and close op replies don't contain a reply header
         if initial_connect or self.pending_specials[protocol.CLOSE_XID]:
-            raw_payload = await self.reader.read(size)
+            raw_payload = await self._read(size)
             response = protocol.ConnectResponse.deserialize(raw_payload)
             return (None, None, response)
 
-        raw_header = await self.reader.read(reply_header_struct.size)
+        raw_header = await self._read(reply_header_struct.size)
         xid, zxid, error_code = reply_header_struct.unpack_from(raw_header)
 
         if error_code:
@@ -188,7 +204,7 @@ class Connection(object):
 
         size -= reply_header_struct.size
 
-        raw_payload = await self.reader.read(size)
+        raw_payload = await self._read(size)
 
         if xid == protocol.WATCH_XID:
             response = protocol.WatchEvent.deserialize(raw_payload)

--- a/aiozk/exc.py
+++ b/aiozk/exc.py
@@ -28,6 +28,10 @@ class TimeoutError(ZKError):
     pass
 
 
+class UnfinishedRead(ZKError):
+    pass
+
+
 class FailedRetry(ZKError):
     pass
 

--- a/aiozk/recipes/base_watcher.py
+++ b/aiozk/recipes/base_watcher.py
@@ -32,11 +32,14 @@ class BaseWatcher(Recipe):
 
     async def watch_loop(self, path):
         while self.callbacks[path]:
+            await self.client.wait_for_event(self.watched_event, path)
+
             log.debug("Fetching data for %s", path)
             try:
                 result = await self.fetch(path)
             except exc.NoNode:
                 return
+
+
             for callback in self.callbacks[path]:
                 asyncio.ensure_future(callback(result))
-            await self.client.wait_for_event(self.watched_event, path)

--- a/aiozk/recipes/base_watcher.py
+++ b/aiozk/recipes/base_watcher.py
@@ -32,14 +32,11 @@ class BaseWatcher(Recipe):
 
     async def watch_loop(self, path):
         while self.callbacks[path]:
-            await self.client.wait_for_event(self.watched_event, path)
-
             log.debug("Fetching data for %s", path)
             try:
                 result = await self.fetch(path)
             except exc.NoNode:
                 return
-
-
             for callback in self.callbacks[path]:
                 asyncio.ensure_future(callback(result))
+            await self.client.wait_for_event(self.watched_event, path)

--- a/aiozk/session.py
+++ b/aiozk/session.py
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 
 class Session(object):
 
-    def __init__(self, servers, timeout, retry_policy, allow_read_only):
+    def __init__(self, servers, timeout, retry_policy, allow_read_only, read_timeout):
         self.loop = asyncio.get_event_loop()
         self.hosts = []
         for server in servers.split(","):
@@ -47,6 +47,7 @@ class Session(object):
         self.session_id = None
         self.timeout = timeout
         self.password = b'\x00'
+        self.read_timeout = read_timeout
 
         self.heartbeat_handle = None
 
@@ -100,7 +101,7 @@ class Session(object):
             self.loop.create_task(self.find_server(allow_read_only=False))
 
     async def make_connection(self, host, port):
-        conn = Connection(host, port, watch_handler=self.event_dispatch)
+        conn = Connection(host, port, watch_handler=self.event_dispatch, read_timeout=self.read_timeout)
         try:
             await conn.connect()
         except Exception:


### PR DESCRIPTION
When reading a relatively large file from zk (~5 kb), StreamReader isn't guaranteed to completely read it in one go. Add chunked read with default timeout of 1 second.