### PR TITLE
Handle incomplete reads from StreamReader

### DIFF
--- a/aiozk/client.py
+++ b/aiozk/client.py
@@ -23,6 +23,7 @@ class ZKClient(object):
             default_acl=None,
             retry_policy=None,
             allow_read_only=False,
+            read_timeout=None
     ):
         self.chroot = None
         if chroot:
@@ -30,7 +31,7 @@ class ZKClient(object):
             log.info("Using chroot '%s'", self.chroot)
 
         self.session = Session(
-            servers, session_timeout, retry_policy, allow_read_only
+            servers, session_timeout, retry_policy, allow_read_only, read_timeout
         )
 
         self.default_acl = default_acl or [protocol.UNRESTRICTED_ACCESS]

--- a/aiozk/connection.py
+++ b/aiozk/connection.py
@@ -10,7 +10,7 @@ from time import time
 
 from aiozk import protocol, iterables, exc
 
-DEFAULT_READ_TIMEOUT = 1
+DEFAULT_READ_TIMEOUT = 3
 
 version_regex = re.compile(rb'Zookeeper version: (\d)\.(\d)\.(\d)-.*')
 

--- a/aiozk/exc.py
+++ b/aiozk/exc.py
@@ -28,6 +28,10 @@ class TimeoutError(ZKError):
     pass
 
 
+class UnfinishedRead(ZKError):
+    pass
+
+
 class FailedRetry(ZKError):
     pass
 

--- a/aiozk/session.py
+++ b/aiozk/session.py
@@ -110,8 +110,8 @@ class Session(object):
         return conn
 
     async def establish_session(self):
-        log.info("Establising session.")
-        zxid, response = await self.conn.send_connect(
+        log.info("Establishing session.")
+        connection_response = await self.conn.send_connect(
             protocol.ConnectRequest(
                 protocol_version=0,
                 last_seen_zxid=self.last_zxid or 0,
@@ -121,6 +121,9 @@ class Session(object):
                 read_only=self.allow_read_only,
             )
         )
+        if connection_response is None:
+            raise exc.SessionLost()
+        zxid, response = connection_response
         self.last_zxid = zxid
 
         if response.session_id == 0:  # invalid session, probably expired

--- a/aiozk/session.py
+++ b/aiozk/session.py
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 
 class Session(object):
 
-    def __init__(self, servers, timeout, retry_policy, allow_read_only):
+    def __init__(self, servers, timeout, retry_policy, allow_read_only, read_timeout):
         self.loop = asyncio.get_event_loop()
         self.hosts = []
         for server in servers.split(","):
@@ -47,6 +47,7 @@ class Session(object):
         self.session_id = None
         self.timeout = timeout
         self.password = b'\x00'
+        self.read_timeout = read_timeout
 
         self.heartbeat_handle = None
 
@@ -100,7 +101,7 @@ class Session(object):
             self.loop.create_task(self.find_server(allow_read_only=False))
 
     async def make_connection(self, host, port):
-        conn = Connection(host, port, watch_handler=self.event_dispatch)
+        conn = Connection(host, port, watch_handler=self.event_dispatch, read_timeout=self.read_timeout)
         try:
             await conn.connect()
         except Exception:

--- a/docker/zk_start.py
+++ b/docker/zk_start.py
@@ -127,7 +127,7 @@ async def dyn_cfg(seed):
                 printe('LOCKED BREAK')
                 break
             printe('retry')
-    printe('ethernal loop')
+    printe('eternal loop')
     while 1:
         time.sleep(1)
 


### PR DESCRIPTION
When reading a relatively large file from zk (~5 kb), StreamReader isn't guaranteed to completely read it in one go. Add chunked read with default timeout of 3 seconds.