### PR TITLE
Uvloop compat fix; fix TestBarrier

### DIFF
--- a/aiozk/iterables.py
+++ b/aiozk/iterables.py
@@ -23,4 +23,4 @@ def drain(iterable):
         try:
             yield next_item(iterable)
         except (IndexError, KeyError):
-            raise StopIteration
+            return

--- a/aiozk/session.py
+++ b/aiozk/session.py
@@ -185,6 +185,8 @@ class Session(object):
                 self.last_zxid = zxid
                 self.set_heartbeat()
                 self.retry_policy.clear(request)
+            except (exc.NodeExists, exc.NoNode):
+                raise
             except exc.ConnectError:
                 self.state.transition_to(States.SUSPENDED)
             except Exception as e:

--- a/aiozk/test/test_barrier.py
+++ b/aiozk/test/test_barrier.py
@@ -10,25 +10,24 @@ class TestBarrier(ZKBase):
     async def worker(self):
         barrier = self.c.recipes.Barrier(NAME)
         await barrier.wait()
-        while True:
-            self.assertEqual(self.lifted, True)
-            await asyncio.sleep(0.3)
+        await asyncio.sleep(0.2)
+        self.assertEqual(self.lifted, True)
 
     async def test_barrier(self):
         self.lifted = False
         barrier = self.c.recipes.Barrier(NAME)
         await barrier.create()
-        asyncio.ensure_future(self.worker())
+        worker = asyncio.ensure_future(self.worker())
         await asyncio.sleep(0.05)
         await barrier.lift()
         self.lifted = True
         await asyncio.sleep(0.1)
+        await worker
 
 
 class TestDoubleBarrier(ZKBase):
     async def worker(self, num, min_workers):
-        c = await self.client()
-        barrier = c.recipes.DoubleBarrier(NAME, min_workers)
+        barrier = self.c.recipes.DoubleBarrier(NAME, min_workers)
 
         await asyncio.sleep(0.01*num)
         await barrier.enter()


### PR DESCRIPTION
1) In uvloop's implementation, StreamReader's _transport doesn't have a _sock property. Use a public method of StreamWriter instead.
2) NoNode and NodeExists exceptions are expected in the normal course of work, they don't need additional logging.
3) On close(), only print a warning about pending tasks if there are any pending tasks.
4) TestBarrier didn't actually check anything.