### PR TITLE
connection: allow multiple-digit version numbers

### DIFF
--- a/aiozk/connection.py
+++ b/aiozk/connection.py
@@ -12,7 +12,7 @@ from aiozk import protocol, iterables, exc
 
 DEFAULT_READ_TIMEOUT = 3
 
-version_regex = re.compile(rb'Zookeeper version: (\d)\.(\d)\.(\d)-.*')
+version_regex = re.compile(rb'Zookeeper version: (\d+)\.(\d+)\.(\d+)-.*')
 
 # all requests and responses are prefixed with a 32-bit int denoting size
 size_struct = struct.Struct("!i")


### PR DESCRIPTION
This allows using Zookeeper 3.4.10.