### PR TITLE
Correct timeout for acquire_ locks

### DIFF
--- a/aiozk/recipes/base_lock.py
+++ b/aiozk/recipes/base_lock.py
@@ -38,7 +38,7 @@ class BaseLock(SequentialRecipe):
             if not blockers:
                 break
 
-            await self.wait_on_sibling(blockers[-1], time_limit)
+            await self.wait_on_sibling(blockers[-1], timeout)
 
         return self.make_contextmanager(znode_label)
 

--- a/aiozk/recipes/base_lock.py
+++ b/aiozk/recipes/base_lock.py
@@ -38,7 +38,10 @@ class BaseLock(SequentialRecipe):
             if not blockers:
                 break
 
-            await self.wait_on_sibling(blockers[-1], timeout)
+            try:
+                await self.wait_on_sibling(blockers[-1], timeout)
+            except exc.TimeoutError:
+                await self.delete_unique_znode(znode_label)
 
         return self.make_contextmanager(znode_label)
 

--- a/aiozk/test/test_shared_lock.py
+++ b/aiozk/test/test_shared_lock.py
@@ -1,0 +1,35 @@
+import asyncio
+import pytest
+from aiozk.exc import TimeoutError
+
+
+@pytest.mark.asyncio
+async def test_shared_lock(zk, path):
+
+    shared = zk.recipes.SharedLock(path)
+    got_lock = False
+    async with await shared.acquire_write():
+        got_lock = True
+
+    assert got_lock
+
+    got_released = False
+    async with await shared.acquire_write():
+        got_released = True
+
+    assert got_released
+    await zk.delete(path)
+
+
+@pytest.mark.asyncio
+async def test_shared_lock_timeout(zk, path):
+    shared = zk.recipes.SharedLock(path)
+    got_lock = False
+    async with await shared.acquire_write():
+        got_lock = True
+
+        with pytest.raises(TimeoutError):
+            await shared.acquire_write(timeout=1)
+
+    assert got_lock
+    await zk.deleteall(path)

--- a/aiozk/test/test_shared_lock.py
+++ b/aiozk/test/test_shared_lock.py
@@ -23,13 +23,19 @@ async def test_shared_lock(zk, path):
 
 @pytest.mark.asyncio
 async def test_shared_lock_timeout(zk, path):
-    shared = zk.recipes.SharedLock(path)
     got_lock = False
-    async with await shared.acquire_write():
+    async with await zk.recipes.SharedLock(path).acquire_write():
         got_lock = True
 
         with pytest.raises(TimeoutError):
-            await shared.acquire_write(timeout=1)
+            await zk.recipes.SharedLock(path).acquire_write(timeout=1)
 
     assert got_lock
+
+    got_released = False
+    async with await zk.recipes.SharedLock(path).acquire_write():
+        got_released = True
+
+    assert got_released
+
     await zk.deleteall(path)


### PR DESCRIPTION
The asycio.wait_for function accepts a number of seconds as parameter for timeout
and what as being passed was a unix timestap making it wait 'forever' for the release of the lock.