### PR TITLE
Correct timeout for acquiring locks

### DIFF
--- a/aiozk/recipes/base_lock.py
+++ b/aiozk/recipes/base_lock.py
@@ -38,7 +38,10 @@ class BaseLock(SequentialRecipe):
             if not blockers:
                 break
 
-            await self.wait_on_sibling(blockers[-1], time_limit)
+            try:
+                await self.wait_on_sibling(blockers[-1], timeout)
+            except exc.TimeoutError:
+                await self.delete_unique_znode(znode_label)
 
         return self.make_contextmanager(znode_label)
 

--- a/aiozk/test/test_shared_lock.py
+++ b/aiozk/test/test_shared_lock.py
@@ -1,0 +1,41 @@
+import asyncio
+import pytest
+from aiozk.exc import TimeoutError
+
+
+@pytest.mark.asyncio
+async def test_shared_lock(zk, path):
+
+    shared = zk.recipes.SharedLock(path)
+    got_lock = False
+    async with await shared.acquire_write():
+        got_lock = True
+
+    assert got_lock
+
+    got_released = False
+    async with await shared.acquire_write():
+        got_released = True
+
+    assert got_released
+    await zk.delete(path)
+
+
+@pytest.mark.asyncio
+async def test_shared_lock_timeout(zk, path):
+    got_lock = False
+    async with await zk.recipes.SharedLock(path).acquire_write():
+        got_lock = True
+
+        with pytest.raises(TimeoutError):
+            await zk.recipes.SharedLock(path).acquire_write(timeout=1)
+
+    assert got_lock
+
+    got_released = False
+    async with await zk.recipes.SharedLock(path).acquire_write():
+        got_released = True
+
+    assert got_released
+
+    await zk.deleteall(path)


### PR DESCRIPTION
Corrects timeout for asyncio.wait_for function. It must be a time in seconds.