### PR TITLE
Network errors and memory leak fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM tipsi/base_python:1.0.6
 
 WORKDIR /code
 
-RUN pip3 install pytest==3.6.* pytest-asyncio
+RUN pip3 install pytest==3.6.* pytest-asyncio asynctest
 RUN apt install -y tcpdump
 
 ADD . /code

--- a/aiozk/connection.py
+++ b/aiozk/connection.py
@@ -217,6 +217,7 @@ class Connection:
         xid, zxid, error_code = reply_header_struct.unpack_from(raw_header)
 
         if error_code:
+            self.opcode_xref.pop(xid)
             return (xid, zxid, exc.get_response_error(error_code))
 
         size -= reply_header_struct.size

--- a/aiozk/connection.py
+++ b/aiozk/connection.py
@@ -188,8 +188,8 @@ class Connection:
         while remaining_size and (time() < end_time):
             remaining_time = end_time - time()
             done, pending = await asyncio.wait([self.reader.read(remaining_size)],
-                                               timeout=remaining_time,
-                                               loop=self.loop)
+                                                timeout=remaining_time,
+                                                loop=self.loop)
             if done:
                 chunk = done.pop().result()
                 payload.append(chunk)
@@ -201,8 +201,9 @@ class Connection:
         return b''.join(payload)
 
     async def read_response(self, initial_connect=False):
-        raw_size = await self._read(size_struct.size)
-        if raw_size == b'':
+        try:
+            raw_size = await self.reader.readexactly(size_struct.size)
+        except asyncio.IncompleteReadError:
             raise ConnectionAbortedError
         size = size_struct.unpack(raw_size)[0]
 

--- a/aiozk/session.py
+++ b/aiozk/session.py
@@ -289,6 +289,9 @@ class Session(object):
         await self.send(request)
 
     async def close(self):
+        if not self.started:
+            log.debug('Do nothing because session is not started')
+            return
         if self.closing:
             return
         self.closing = True

--- a/aiozk/session.py
+++ b/aiozk/session.py
@@ -196,13 +196,15 @@ class Session(object):
                 self.set_heartbeat()
                 self.retry_policy.clear(request)
             except (exc.NodeExists, exc.NoNode, exc.NotEmpty):
+                self.retry_policy.clear(request)
                 raise
             except asyncio.CancelledError:
-                pass
+                self.retry_policy.clear(request)
             except exc.ConnectError:
                 self.state.transition_to(States.SUSPENDED)
             except Exception as e:
                 log.exception('Send exception: {}'.format(e))
+                self.retry_policy.clear(request)
                 raise e
         return response
 

--- a/aiozk/test/test_session.py
+++ b/aiozk/test/test_session.py
@@ -1,0 +1,22 @@
+import unittest
+from unittest import mock
+
+import asynctest
+from aiozk import session
+
+
+class TestSession(asynctest.TestCase):
+
+    def setUp(self):
+        self.fake_retry_policy = mock.MagicMock()
+        self.fake_loop = mock.MagicMock()
+        self.session = session.Session('zookeeper.test', 10, self.fake_retry_policy, True, 30, loop=self.fake_loop)
+
+    async def test_start_session_twice(self):
+        with mock.patch.object(self.session, 'ensure_safe_state', asynctest.CoroutineMock()) as ensure_safe_state:
+            await self.session.start()
+            await self.session.start()
+
+            self.fake_loop.call_soon.assert_called_once()
+            self.fake_loop.create_task.assert_called_once()
+            ensure_safe_state.assert_called_once()

--- a/aiozk/test/test_session.py
+++ b/aiozk/test/test_session.py
@@ -6,11 +6,6 @@ import aiozk
 import pytest
 
 
-def coroutine_mock(return_value=None):
-    stub = mock.Mock(return_value=return_value)
-    return asyncio.coroutine(stub)
-
-
 @pytest.fixture
 def session():
     fake_retry_policy = mock.MagicMock()
@@ -20,13 +15,16 @@ def session():
 
 @pytest.mark.asyncio
 async def test_start_session_twice(session):
-    with mock.patch.object(session, 'ensure_safe_state', coroutine_mock()) as ensure_safe_state:
+    ensure_safe_state = mock.Mock()
+    with mock.patch.object(session, 'ensure_safe_state', asyncio.coroutine(ensure_safe_state)):
         await session.start()
+        ensure_safe_state.assert_called_once_with()
+        ensure_safe_state.reset_mock()
         await session.start()
+        ensure_safe_state.assert_called_once_with()
 
         session.loop.call_soon.assert_called_once()
         session.loop.create_task.assert_called_once()
-        ensure_safe_state.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/aiozk/test/test_session.py
+++ b/aiozk/test/test_session.py
@@ -1,33 +1,107 @@
 import asyncio
 from unittest import mock
 
-import aiozk
+import aiozk.session
 
 import pytest
+import asynctest
+
+from aiozk import exc
 
 
 @pytest.fixture
-def session():
-    fake_retry_policy = mock.MagicMock()
-    fake_loop = mock.MagicMock()
-    return aiozk.session.Session('zookeeper.test', 10, fake_retry_policy, True, 30, loop=fake_loop)
+def session(event_loop):
+    fake_retry_policy = asynctest.MagicMock(wraps=aiozk.session.RetryPolicy.forever())
+    session = aiozk.session.Session(
+        'zookeeper.test',
+        timeout=10,
+        retry_policy=fake_retry_policy,
+        allow_read_only=True,
+        read_timeout=30,
+        loop=asynctest.MagicMock(wraps=event_loop),
+    )
+    session.state.transition_to(aiozk.session.States.CONNECTED)
+    session.conn = asynctest.MagicMock()
+    session.conn.send = asynctest.CoroutineMock()
+    session.ensure_safe_state = asynctest.CoroutineMock()
+    session.set_heartbeat = mock.Mock()
+    return session
 
 
 @pytest.mark.asyncio
 async def test_start_session_twice(session):
-    ensure_safe_state = mock.Mock()
-    with mock.patch.object(session, 'ensure_safe_state', asyncio.coroutine(ensure_safe_state)):
-        await session.start()
-        ensure_safe_state.assert_called_once_with()
-        ensure_safe_state.reset_mock()
-        await session.start()
-        ensure_safe_state.assert_called_once_with()
+    await session.start()
+    session.ensure_safe_state.assert_called_once_with()
+    session.ensure_safe_state.reset_mock()
+    await session.start()
+    session.ensure_safe_state.assert_called_once_with()
 
-        session.loop.call_soon.assert_called_once()
-        session.loop.create_task.assert_called_once()
+    session.loop.call_soon.assert_called_once()
+    session.loop.create_task.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_close_not_started(session):
     await session.close()
     assert not session.closing
+
+
+@pytest.mark.asyncio
+async def test_send_no_node(session):
+    req = mock.MagicMock()
+    session.conn.send.side_effect = exc.NoNode
+    with pytest.raises(exc.NoNode):
+        await session.send(req)
+
+    session.retry_policy.clear.assert_called_once_with(req)
+    session.conn.send.assert_called_once()
+    session.set_heartbeat.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_canceled(session):
+    req = mock.MagicMock()
+    session.conn.send.side_effect = asyncio.CancelledError
+    with pytest.raises(asyncio.CancelledError):
+        await session.send(req)
+
+    session.retry_policy.clear.assert_called_once_with(req)
+    session.conn.send.assert_called_once()
+    session.set_heartbeat.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_connection_error(session):
+    zxid = 1
+    session.conn.send.side_effect = [exc.ConnectError('zookeeper.test', '2181'), (zxid, mock.MagicMock())]
+    req = mock.MagicMock()
+    await session.send(req)
+
+    session.retry_policy.clear.assert_called_once_with(req)
+    assert session.conn.send.call_count == 2
+    session.set_heartbeat.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_send_unknown_error(session):
+    req = mock.MagicMock()
+    session.conn.send.side_effect = RuntimeError
+    with pytest.raises(RuntimeError):
+        await session.send(req)
+
+    session.retry_policy.clear.assert_called_once_with(req)
+    session.conn.send.assert_called_once()
+    session.set_heartbeat.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_good_case(session):
+    zxid = 1
+    req = mock.MagicMock()
+    resp = mock.MagicMock()
+    session.conn.send.return_value = (zxid, resp)
+    await session.send(req)
+
+    session.retry_policy.clear.assert_called_once_with(req)
+    session.conn.send.assert_called_once()
+    session.set_heartbeat.assert_called_once_with()

--- a/aiozk/test/test_session.py
+++ b/aiozk/test/test_session.py
@@ -28,6 +28,7 @@ async def test_start_session_twice(session):
         session.loop.create_task.assert_called_once()
         ensure_safe_state.assert_called_once()
 
+
 @pytest.mark.asyncio
 async def test_close_not_started(session):
     await session.close()

--- a/aiozk/test/test_session.py
+++ b/aiozk/test/test_session.py
@@ -3,7 +3,6 @@ from unittest import mock
 
 import aiozk
 
-import asynctest
 import pytest
 
 

--- a/aiozk/test/test_watchers.py
+++ b/aiozk/test/test_watchers.py
@@ -3,7 +3,7 @@ import uuid
 
 import pytest
 
-from aiozk.exc import NoNode
+from ..exc import NoNode
 
 
 @pytest.fixture

--- a/aiozk/test/test_watchers.py
+++ b/aiozk/test/test_watchers.py
@@ -3,7 +3,7 @@ import uuid
 
 import pytest
 
-from ..exc import NoNode
+from aiozk.exc import NoNode
 
 
 @pytest.fixture

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'flake8',
         'pytest',
         'pytest-asyncio',
+        'asynctest',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
* fixed error handling during connecting
* fixed size reading for payload
* fixed opcode dict cleanup for absent nodes(which lead to "memory leakage" when config tree is actively moving)