### PR TITLE
Allow waiting for znode creation in DataWatcher

### DIFF
--- a/aiozk/recipes/data_watcher.py
+++ b/aiozk/recipes/data_watcher.py
@@ -1,4 +1,5 @@
 from aiozk import WatchEvent
+from aiozk.exc import NoNode
 
 from .base_watcher import BaseWatcher
 
@@ -7,6 +8,18 @@ class DataWatcher(BaseWatcher):
 
     watched_events = [WatchEvent.DATA_CHANGED, WatchEvent.DELETED]
 
+    def __init__(self, *args, wait_for_create=False, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if wait_for_create:
+            self.watched_events.append(WatchEvent.CREATED)
+
     async def fetch(self, path):
-        data = await self.client.get_data(path=path, watch=True)
+        # exists() gives create, delete, and update watches
+        watch_via_exists = WatchEvent.CREATED in self.watched_events
+        if watch_via_exists:
+            exists = await self.client.exists(path, watch=True)
+            if not exists:
+                raise NoNode
+        data = await self.client.get_data(path=path, watch=not watch_via_exists)
         return data


### PR DESCRIPTION
This PR adds the ability for DataWatcher to use exists() to watch for updates. This has the effect of allowing a callback to fire on node creation, update, and deletion by adding the wait_for_create flag to DataWatcher.
When that flag is present, DataWatcher will issue an exists() call before a get_data() call in fetch(). Existing semantics are maintained if the flag is not present (including number of round trips to zookeeper)

Reasoning: In my app, the watched node not existing is not an error condition it merely means that the process is early or a leader isn't running. Basically, I'd like the ability for one callback to watch as a node appears, changes, and/or goes away.

This would technically fix #15, though I'd like to acknowledge the approach in this PR is not discussed in that issue.