### PR TITLE
Handle issue with inconsistent zxid on reconnection

### DIFF
--- a/aiozk/session.py
+++ b/aiozk/session.py
@@ -134,6 +134,7 @@ class Session(object):
             )
         )
         if connection_response is None:
+            self.last_zxid = None
             raise exc.SessionLost()
         zxid, response = connection_response
         self.last_zxid = zxid

--- a/aiozk/session.py
+++ b/aiozk/session.py
@@ -191,6 +191,7 @@ class Session(object):
             log.error(
                 'Repair loop task failed with exception: {error}'.format(error=error)
             )
+            raise error
 
     async def send(self, request):
         response = None

--- a/aiozk/test/test_client.py
+++ b/aiozk/test/test_client.py
@@ -61,6 +61,21 @@ async def test_inconsistent_zxid():
     except asyncio.TimeoutError as exc:
         pytest.fail("Failed with timeout on session reconnection attemt")
 
+
+@pytest.mark.asyncio
+async def test_session_reconnect():
+    async def coro():
+        zk = get_client()
+        await zk.start()
+        await zk.session.close()
+        await zk.session.start()
+        await zk.session.close()
+    try:
+        await asyncio.wait_for(coro(), timeout=10)
+    except asyncio.TimeoutError as exc:
+        pytest.fail("Failed with timeout on session reconnection attemt")
+
+
 @pytest.mark.asyncio
 async def test_raw_get(full_zk, path):
     # type: (aiozk.ZKClient, str) -> None

--- a/aiozk/test/test_client.py
+++ b/aiozk/test/test_client.py
@@ -5,7 +5,6 @@ import pytest
 
 from aiozk import WatchEvent
 from .conftest import get_client
-from aiozk.session import States
 
 
 logging.getLogger('asyncio').setLevel(logging.DEBUG)


### PR DESCRIPTION
We can get an infinite loop of reconnections when zxid was changed on the server and we attempt to connect with old zxid